### PR TITLE
rx - Copy MenuItemReview Backend API from team01

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,156 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for MenuItemReview */
+@Tag(name = "MenuItemReview")
+@RequestMapping("/api/menuitemreview")
+@RestController
+@Slf4j
+public class MenuItemReviewController extends ApiController {
+
+  @Autowired MenuItemReviewRepository menuItemReviewRepository;
+
+  /**
+   * List all menu item reviews
+   *
+   * @return an iterable of MenuItemReview
+   */
+  @Operation(summary = "List all menu item reviews")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<MenuItemReview> allMenuItemReviews() {
+    Iterable<MenuItemReview> reviews = menuItemReviewRepository.findAll();
+    return reviews;
+  }
+
+  /**
+   * Create a new menu item review
+   *
+   * @param itemId id of the menu item being reviewed
+   * @param reviewerEmail the email of the reviewer
+   * @param stars the stars (0-5) given to the menu item
+   * @param dateReviewed the datetime when the review was created
+   * @param comments reviewer's text about reviewed menu item
+   * @return the saved menuitemreview
+   */
+  @Operation(summary = "Create a new menu item review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public MenuItemReview postMenuItemReview(
+      @Parameter(name = "itemId") @RequestParam long itemId,
+      @Parameter(name = "reviewerEmail") @RequestParam String reviewerEmail,
+      @Parameter(name = "stars", description = "0 to 5 stars") @RequestParam int stars,
+      @Parameter(
+              name = "dateReviewed",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateReviewed")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateReviewed,
+      @Parameter(name = "comments") @RequestParam String comments)
+      throws JsonProcessingException {
+
+    // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    // See: https://www.baeldung.com/spring-date-parameters
+
+    log.info("dateReviewed={}", dateReviewed);
+
+    MenuItemReview menuItemReview = new MenuItemReview();
+    menuItemReview.setItemId(itemId);
+    menuItemReview.setReviewerEmail(reviewerEmail);
+    menuItemReview.setStars(stars);
+    menuItemReview.setDateReviewed(dateReviewed);
+    menuItemReview.setComments(comments);
+
+    MenuItemReview savedMenuItemReview = menuItemReviewRepository.save(menuItemReview);
+
+    return savedMenuItemReview;
+  }
+
+  /**
+   * Get a menu item review by id
+   *
+   * @param id the id of the menu item review
+   * @return a MenuItemReview
+   */
+  @Operation(summary = "Get a single menu item review")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public MenuItemReview getById(@Parameter(name = "id") @RequestParam Long id) {
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    return menuItemReview;
+  }
+
+  /**
+   * Delete a MenuItemReview
+   *
+   * @param id the id of the menu item review to delete
+   * @return a message indicating the menu item review was deleted
+   */
+  @Operation(summary = "Delete a MenuItemReview")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteMenuItemReview(@Parameter(name = "id") @RequestParam Long id) {
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    menuItemReviewRepository.delete(menuItemReview);
+    return genericMessage("MenuItemReview with id %s deleted".formatted(id));
+  }
+
+  /**
+   * Update a single menu item review
+   *
+   * @param id id of the menu item review to update
+   * @param incoming the new menu item review
+   * @return the updated menu item review object
+   */
+  @Operation(summary = "Update a single menu item review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public MenuItemReview updateMenuItemReview(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid MenuItemReview incoming) {
+
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    menuItemReview.setItemId(incoming.getItemId());
+    menuItemReview.setReviewerEmail(incoming.getReviewerEmail());
+    menuItemReview.setStars(incoming.getStars());
+    menuItemReview.setDateReviewed(incoming.getDateReviewed());
+    menuItemReview.setComments(incoming.getComments());
+
+    menuItemReviewRepository.save(menuItemReview);
+
+    return menuItemReview;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a MenuItemReivew
+ *
+ * <p>A MenuItemReview is a review of an item on a menu at one of the UCSB dining commons
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "menuitemreview")
+public class MenuItemReview {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private long itemId;
+  private String reviewerEmail;
+  private int stars;
+  private LocalDateTime dateReviewed;
+  private String comments;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** The MenuItemReviewRepository is a repository for MenuItemReview entities */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> {}

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -1,0 +1,72 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "MenuItemReview-1",
+          "author": "rayxzw",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "MENUITEMREVIEW"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "MENUITEMREVIEW_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ITEM_ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REVIEWER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STARS",
+                      "type": "INT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REVIEWED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COMMENTS",
+                      "type": "VARCHAR(255)"
+                    }
+                  }]
+                ,
+                "tableName": "MENUITEMREVIEW"
+              }
+            }]
+
+        }
+    }
+]}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,0 +1,376 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewControllerTests extends ControllerTestCase {
+
+  @MockitoBean MenuItemReviewRepository menuItemReviewRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/menuitemreview/admin/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/menuitemreview/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/menuitemreview/all")).andExpect(status().is(200)); // logged
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/menuitemreview").param("id", "7"))
+        .andExpect(status().is(403)); // logged out users can't get by id
+  }
+
+  // Authorization tests for /api/menuitemreview/post
+  // (Perhaps should also have these for put and delete)
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/menuitemreview/post")
+                .param("itemId", "1")
+                .param("reviewerEmail", "a@a.com")
+                .param("stars", "2")
+                .param("dateReviewed", "2022-01-03T00:00:00")
+                .param("comments", "asdf")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/menuitemreview/post")
+                .param("itemId", "1")
+                .param("reviewerEmail", "a@a.com")
+                .param("stars", "2")
+                .param("dateReviewed", "2022-01-03T00:00:00")
+                .param("comments", "asdf")
+                .with(csrf()))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  // // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview mir1 =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("a@a.com")
+            .stars(2)
+            .dateReviewed(ldt)
+            .comments("adsf")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.of(mir1));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/menuitemreview").param("id", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(mir1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    // arrange
+
+    when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/menuitemreview").param("id", "7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("MenuItemReview with id 7 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_menuitemreviews() throws Exception {
+
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview mir1 =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("a@a.com")
+            .stars(2)
+            .dateReviewed(ldt1)
+            .comments("adsf")
+            .build();
+
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+    MenuItemReview mir2 =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("a@a.com")
+            .stars(2)
+            .dateReviewed(ldt2)
+            .comments("adsf")
+            .build();
+
+    ArrayList<MenuItemReview> expectedMirs = new ArrayList<>();
+    expectedMirs.addAll(Arrays.asList(mir1, mir2));
+
+    when(menuItemReviewRepository.findAll()).thenReturn(expectedMirs);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/menuitemreview/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+
+    verify(menuItemReviewRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedMirs);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_menuitemreview() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview mir1 =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("a@a.com")
+            .stars(2)
+            .dateReviewed(ldt1)
+            .comments("adsf")
+            .build();
+
+    when(menuItemReviewRepository.save(eq(mir1))).thenReturn(mir1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/menuitemreview/post")
+                    .param("itemId", "1")
+                    .param("reviewerEmail", "a@a.com")
+                    .param("stars", "2")
+                    .param("dateReviewed", "2022-01-03T00:00:00")
+                    .param("comments", "adsf")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).save(mir1);
+    String expectedJson = mapper.writeValueAsString(mir1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_a_menuitemreview() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview mir1 =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("a@a.com")
+            .stars(1)
+            .dateReviewed(ldt1)
+            .comments("adsf")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.of(mir1));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/menuitemreview").param("id", "15").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(15L);
+    verify(menuItemReviewRepository, times(1)).delete(any());
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("MenuItemReview with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existant_menuitemreview_and_gets_right_error_message()
+      throws Exception {
+    // arrange
+
+    when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/menuitemreview").param("id", "15").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(15L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("MenuItemReview with id 15 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_menuitemreview() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+    MenuItemReview mirOrig =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("a@a.com")
+            .stars(1)
+            .dateReviewed(ldt1)
+            .comments("adsf")
+            .build();
+
+    MenuItemReview mirEdited =
+        MenuItemReview.builder()
+            .itemId(2)
+            .reviewerEmail("b@a.com")
+            .stars(5)
+            .dateReviewed(ldt2)
+            .comments("greatest update ever")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(mirEdited);
+
+    when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.of(mirOrig));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/menuitemreview")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(67L);
+    verify(menuItemReviewRepository, times(1)).save(mirEdited); // should be saved with correct user
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_menuitemreview_that_does_not_exist() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview mirEdited =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("a@a.com")
+            .stars(5)
+            .dateReviewed(ldt1)
+            .comments("greatest update ever II")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(mirEdited);
+
+    when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/menuitemreview")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(67L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("MenuItemReview with id 67 not found", json.get("message"));
+  }
+}


### PR DESCRIPTION
Closes #29 
The files from team01 for implementing the MenuItemReview API was copied over so that the endpoints work for team02 as well.
The jacoco and mutationCoverage are both 100%.

Dokku instance: https://team02-rayxzw-dev.dokku-07.cs.ucsb.edu/ 

POST:
<img width="1360" height="1048" alt="image" src="https://github.com/user-attachments/assets/6023d18d-07d6-4477-afb9-d29a22161da8" />

GET /all:
<img width="1350" height="685" alt="image" src="https://github.com/user-attachments/assets/08f6f0ee-2385-4c2e-a355-9aeeaf4959aa" />

GET single:
<img width="1371" height="765" alt="image" src="https://github.com/user-attachments/assets/c4735cea-8f25-4700-92c9-d35a6216d1c3" />

PUT:
<img width="1345" height="987" alt="image" src="https://github.com/user-attachments/assets/3d8ad35f-4698-4817-94d1-212b5ac6e8dd" />

DELETE:
<img width="1336" height="713" alt="image" src="https://github.com/user-attachments/assets/96b3db51-0207-4f9f-a7d4-90301952ff7c" />

GET after DELETE:
<img width="1350" height="622" alt="image" src="https://github.com/user-attachments/assets/2578f202-b688-4f07-b0c8-5d4dfc69c4e1" />

