### PR TITLE
Add placeholder pages for UCSBOrganization and navbar link

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,7 +14,9 @@ import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
-
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
 import { hasRole, useCurrentUser } from "main/utils/useCurrentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -85,6 +87,17 @@ function App() {
             path="/placeholder/create"
             element={<PlaceholderCreatePage />}
           />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route exact path="/ucsborganization" element={<UCSBOrganizationIndexPage />} />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route exact path="/ucsborganization/edit/:id" element={<UCSBOrganizationEditPage />} />
+          <Route exact path="/ucsborganization/create" element={<UCSBOrganizationCreatePage />} />
         </>
       )}
     </Routes>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -91,13 +91,25 @@ function App() {
       )}
       {hasRole(currentUser, "ROLE_USER") && (
         <>
-          <Route exact path="/ucsborganization" element={<UCSBOrganizationIndexPage />} />
+          <Route
+            exact
+            path="/ucsborganization"
+            element={<UCSBOrganizationIndexPage />}
+          />
         </>
       )}
       {hasRole(currentUser, "ROLE_ADMIN") && (
         <>
-          <Route exact path="/ucsborganization/edit/:id" element={<UCSBOrganizationEditPage />} />
-          <Route exact path="/ucsborganization/create" element={<UCSBOrganizationCreatePage />} />
+          <Route
+            exact
+            path="/ucsborganization/edit/:id"
+            element={<UCSBOrganizationEditPage />}
+          />
+          <Route
+            exact
+            path="/ucsborganization/create"
+            element={<UCSBOrganizationCreatePage />}
+          />
         </>
       )}
     </Routes>

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -71,6 +71,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/ucsborganization">
+                    UCSBOrganization
+                  </Nav.Link>
                 </>
               ) : (
                 <></>

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
@@ -1,0 +1,11 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+export default function UCSBOrganizationCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
@@ -1,0 +1,11 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+export default function UCSBOrganizationEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.jsx
@@ -1,0 +1,17 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+export default function UCSBOrganizationIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/ucsborganization/create">Create</a>
+        </p>
+        <p>
+          <a href="/ucsborganization/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("UCSBOrganizationCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+    setupUserOnly();
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    // assert
+    await screen.findByText("Create page not yet implemented");
+    expect(
+      screen.getByText("Create page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("UCSBOrganizationEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+    setupUserOnly();
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    // assert
+    await screen.findByText("Edit page not yet implemented");
+    expect(
+      screen.getByText("Edit page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("UCSBOrganizationIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+    setupUserOnly();
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    await screen.findByText("Index page not yet implemented");
+    // assert
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #15

## What this PR does

Adds placeholder pages for `UCSBOrganization` and adds a link to the navbar.

## Files Added

- `frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx`
- `frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx`
- `frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.jsx`
- `frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx`
- `frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx`
- `frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.jsx`

## Files Modified

- `frontend/src/App.jsx`
- `frontend/src/main/components/Nav/AppNavbar.jsx`

## Testing

- Frontend tests pass with `npm test`
- Code formatting verified with prettier