### PR TITLE
Add Edit Page for UCSBOrganization plus tests and stories

### DIFF
--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
@@ -1,10 +1,77 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-export default function UCSBOrganizationEditPage() {
-  // Stryker disable all : placeholder for future implementation
+import { useParams } from "react-router";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function UCSBOrganizationEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: ucsbOrganization,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/ucsborganizations?orgCode=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/ucsborganizations`,
+      params: {
+        orgCode: id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (ucsbOrganization) => ({
+    url: "/api/ucsborganizations",
+    method: "PUT",
+    params: {
+      orgCode: ucsbOrganization.orgCode,
+    },
+    data: {
+      orgTranslationShort: ucsbOrganization.orgTranslationShort,
+      orgTranslation: ucsbOrganization.orgTranslation,
+      inactive: ucsbOrganization.inactive,
+    },
+  });
+
+  const onSuccess = (ucsbOrganization) => {
+    toast(
+      `UCSBOrganization Updated - orgCode: ${ucsbOrganization.orgCode} orgTranslationShort: ${ucsbOrganization.orgTranslationShort}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/ucsborganizations?orgCode=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganization" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit UCSBOrganization</h1>
+        {ucsbOrganization && (
+          <UCSBOrganizationForm
+            initialContents={ucsbOrganization}
+            submitAction={onSubmit}
+            buttonLabel="Update"
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import { http, HttpResponse } from "msw";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+
+export default {
+  title: "pages/UCSBOrganization/UCSBOrganizationEditPage",
+  component: UCSBOrganizationEditPage,
+};
+
+const Template = () => <UCSBOrganizationEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/ucsborganizations", () => {
+      return HttpResponse.json(ucsbOrganizationFixtures.threeOrganizations[0], {
+        status: 200,
+      });
+    }),
+    http.put("/api/ucsborganizations", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
@@ -1,41 +1,188 @@
-import { render, screen } from "@testing-library/react";
-import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+import mockConsole from "tests/testutils/mockConsole";
 
-describe("UCSBOrganizationEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
   };
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-    setupUserOnly();
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <UCSBOrganizationEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-    // assert
-    await screen.findByText("Edit page not yet implemented");
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: "ZPR",
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+let axiosMock;
+describe("UCSBOrganizationEditPage tests", () => {
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/ucsborganizations", { params: { orgCode: "ZPR" } })
+        .timeout();
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByText("Edit UCSBOrganization");
+      expect(
+        screen.queryByTestId("UCSBOrganizationForm-orgTranslationShort"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/ucsborganizations", { params: { orgCode: "ZPR" } })
+        .reply(200, {
+          orgCode: "ZPR",
+          orgTranslationShort: "ZETA PHI RHO",
+          orgTranslation: "ZETA PHI RHO FRATERNITY",
+          inactive: false,
+        });
+      axiosMock.onPut("/api/ucsborganizations").reply(200, {
+        orgCode: "ZPR",
+        orgTranslationShort: "ZETA PHI RHO UPDATED",
+        orgTranslation: "ZETA PHI RHO FRATERNITY UPDATED",
+        inactive: true,
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+      const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
+      const orgTranslationShortField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslationShort",
+      );
+      const orgTranslationField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslation",
+      );
+      const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+      expect(orgCodeField).toHaveValue("ZPR");
+      expect(orgTranslationShortField).toHaveValue("ZETA PHI RHO");
+      expect(orgTranslationField).toHaveValue("ZETA PHI RHO FRATERNITY");
+      expect(submitButton).toHaveTextContent("Update");
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+      const orgTranslationShortField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslationShort",
+      );
+      const orgTranslationField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslation",
+      );
+      const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+      fireEvent.change(orgTranslationShortField, {
+        target: { value: "ZETA PHI RHO UPDATED" },
+      });
+      fireEvent.change(orgTranslationField, {
+        target: { value: "ZETA PHI RHO FRATERNITY UPDATED" },
+      });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "UCSBOrganization Updated - orgCode: ZPR orgTranslationShort: ZETA PHI RHO UPDATED",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ orgCode: "ZPR" });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          orgTranslationShort: "ZETA PHI RHO UPDATED",
+          orgTranslation: "ZETA PHI RHO FRATERNITY UPDATED",
+          inactive: false,
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #18

## What this PR does

Adds an edit page for `UCSBOrganization` along with tests and storybook stories.

## Files Modified

- `frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx`
- `frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx`

## Files Added

- `frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.jsx`

## Testing

To test this page:
1. Navigate to `/ucsborganization` and click Edit on a record as admin
2. Verify the form is pre-populated with the record's data
3. Change some fields and click Update - verify the record is updated
4. Try submitting invalid data - verify error messages appear
5. Click Cancel - verify you are taken back to the previous page

<img width="2748" height="776" alt="image" src="https://github.com/user-attachments/assets/1c3d75a1-97cc-4431-8842-c404c4251660" />
