### PR TITLE
ey - CreatePage for RecommendationRequests

### DIFF
--- a/frontend/src/main/pages/RecommendationRequests/RecommendationRequestsCreatePage.jsx
+++ b/frontend/src/main/pages/RecommendationRequests/RecommendationRequestsCreatePage.jsx
@@ -1,11 +1,54 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RecommendationRequestForm from "main/components/RecommendationRequests/RecommendationRequestForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function RecommendationRequestsCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function RecommendationRequestsCreatePage({
+  storybook = false,
+}) {
+  const objectToAxiosParams = (recommendationRequest) => ({
+    url: "/api/recommendationrequests/post",
+    method: "POST",
+    params: {
+      requesterEmail: recommendationRequest.requesterEmail,
+      professorEmail: recommendationRequest.professorEmail,
+      explanation: recommendationRequest.explanation,
+      dateRequested: recommendationRequest.dateRequested,
+      dateNeeded: recommendationRequest.dateNeeded,
+      done: recommendationRequest.done,
+    },
+  });
+
+  const onSuccess = (recommendationRequest) => {
+    toast(
+      `New recommendationRequest Created - id: ${recommendationRequest.id} explanation: ${recommendationRequest.explanation}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/recommendationrequests/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/recommendationrequests" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New RecommendationRequest</h1>
+
+        <RecommendationRequestForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/RecommendationRequests/RecommendationRequestsCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/RecommendationRequests/RecommendationRequestsCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import RecommendationRequestsCreatePage from "main/pages/RecommendationRequests/RecommendationRequestsCreatePage";
+
+export default {
+  title: "pages/RecommendationRequests/RecommendationRequestsCreatePage",
+  component: RecommendationRequestsCreatePage,
+};
+
+const Template = () => <RecommendationRequestsCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/recommendationrequests/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/RecommendationRequests/RecommendationRequestsCreatePage.test.jsx
+++ b/frontend/src/tests/pages/RecommendationRequests/RecommendationRequestsCreatePage.test.jsx
@@ -126,17 +126,16 @@ describe("RecommendationRequestsCreatePage tests", () => {
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
     expect(axiosMock.history.post[0].params).toEqual({
-      id: 17,
       requesterEmail: "wer@uni.com",
       professorEmail: "abo@cob.org",
       explanation: "Salutations",
-      dateRequested: "2072-01-02T12:00:00",
-      dateNeeded: "2073-01-02T12:00:01",
+      dateRequested: "2072-02-02T00:00",
+      dateNeeded: "2073-02-02T00:00",
       done: false,
     });
 
     expect(mockToast).toBeCalledWith(
-      "New recommendationRequest Created - id: 17 explanation: Salutations",
+      "New recommendationRequest Created - id: 17 explanation: HELP MEE", // initial, not after edit
     );
     expect(mockNavigate).toBeCalledWith({ to: "/recommendationrequests" });
   });

--- a/frontend/src/tests/pages/RecommendationRequests/RecommendationRequestsCreatePage.test.jsx
+++ b/frontend/src/tests/pages/RecommendationRequests/RecommendationRequestsCreatePage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import RecommendationRequestsCreatePage from "main/pages/RecommendationRequests/RecommendationRequestsCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
@@ -7,12 +7,32 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("RecommendationRequestsCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -21,15 +41,10 @@ describe("RecommendationRequestsCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
+    const queryClient = new QueryClient();
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -38,11 +53,91 @@ describe("RecommendationRequestsCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("RecommendationRequestForm-requesterEmail"),
+      ).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+  test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+    const queryClient = new QueryClient();
+    const recommendationRequest = {
+      id: 17,
+      requesterEmail: "ppop@ucsb.edu",
+      professorEmail: "bbob@ucsb.edu",
+      explanation: "HELP MEE",
+      dateRequested: "2022-01-02T12:00:00",
+      dateNeeded: "2023-01-02T12:00:01",
+      done: true,
+    };
+
+    axiosMock
+      .onPost("/api/recommendationrequests/post")
+      .reply(202, recommendationRequest);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("RecommendationRequestForm-requesterEmail"),
+      ).toBeInTheDocument();
+    });
+
+    const requesterEmailField = screen.getByTestId(
+      "RecommendationRequestForm-requesterEmail",
+    );
+    const professorEmailField = screen.getByTestId(
+      "RecommendationRequestForm-professorEmail",
+    );
+    const explanationField = screen.getByTestId(
+      "RecommendationRequestForm-explanation",
+    );
+    const dateRequestedField = screen.getByTestId(
+      "RecommendationRequestForm-dateRequested",
+    );
+    const dateNeededField = screen.getByTestId(
+      "RecommendationRequestForm-dateNeeded",
+    );
+    const doneField = screen.getByTestId("RecommendationRequestForm-done");
+    const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
+
+    fireEvent.change(requesterEmailField, { target: { value: "wer@uni.com" } });
+    fireEvent.change(professorEmailField, { target: { value: "abo@cob.org" } });
+    fireEvent.change(explanationField, { target: { value: "Salutations" } });
+    fireEvent.change(dateRequestedField, {
+      target: { value: "2072-02-02T00:00" },
+    });
+    fireEvent.change(dateNeededField, {
+      target: { value: "2073-02-02T00:00" },
+    });
+    fireEvent.change(doneField, { target: { value: false } });
+
+    expect(submitButton).toBeInTheDocument();
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      id: 17,
+      requesterEmail: "wer@uni.com",
+      professorEmail: "abo@cob.org",
+      explanation: "Salutations",
+      dateRequested: "2072-01-02T12:00:00",
+      dateNeeded: "2073-01-02T12:00:01",
+      done: false,
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New recommendationRequest Created - id: 17 explanation: Salutations",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/recommendationrequests" });
   });
 });


### PR DESCRIPTION
Closes #25 

Should be merged AFTER #23 and #24.

Implemented CreatePage for RecommendationRequests.

[Storybook link](https://ucsb-cs156-s26.github.io/team02-s26-07/prs/77/chromatic)

Testing instructions:

- login to to https://team02-dev-coragon42.dokku-07.cs.ucsb.edu/
- go to create page for RecommendationRequests using top nav bar
- fill in the fields (invalid inputs should be natively guarded by HTML datatypes)
- click create
- check /api/recommendationrequests/all endpoint on Swagger for the new record you just added

Here's a screenshot of what you should expect:
<img width="2586" height="364" alt="image" src="https://github.com/user-attachments/assets/7ff01a69-ed55-4867-8176-d8c6a7d0a77e" />
<img width="1081" height="747" alt="image" src="https://github.com/user-attachments/assets/401d7bae-b950-45fa-a75d-0b40eb2b276d" />