### PR TITLE
ey - fixed UCSBOrganization url plural inconsistency

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -157,7 +157,7 @@ function App() {
         <>
           <Route
             exact
-            path="/ucsborganization"
+            path="/ucsborganizations"
             element={<UCSBOrganizationIndexPage />}
           />
         </>
@@ -166,12 +166,12 @@ function App() {
         <>
           <Route
             exact
-            path="/ucsborganization/edit/:id"
+            path="/ucsborganizations/edit/:id"
             element={<UCSBOrganizationEditPage />}
           />
           <Route
             exact
-            path="/ucsborganization/create"
+            path="/ucsborganizations/create"
             element={<UCSBOrganizationCreatePage />}
           />
         </>

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -71,7 +71,7 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/menuitemreview">
                     Menu Item Reviews
                   </Nav.Link>
-                  <Nav.Link as={Link} to="/ucsborganization">
+                  <Nav.Link as={Link} to="/ucsborganizations">
                     UCSBOrganization
                   </Nav.Link>
                   <Nav.Link as={Link} to="/diningcommonsmenuitem">

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
@@ -36,7 +36,7 @@ export default function UCSBOrganizationCreatePage({ storybook = false }) {
   };
 
   if (isSuccess && !storybook) {
-    return <Navigate to="/ucsborganization" />;
+    return <Navigate to="/ucsborganizations" />;
   }
 
   return (

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
@@ -58,7 +58,7 @@ export default function UCSBOrganizationEditPage({ storybook = false }) {
   };
 
   if (isSuccess && !storybook) {
-    return <Navigate to="/ucsborganization" />;
+    return <Navigate to="/ucsborganizations" />;
   }
 
   return (

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.jsx
@@ -13,7 +13,7 @@ export default function UCSBOrganizationIndexPage() {
       return (
         <Button
           variant="primary"
-          href="/ucsborganization/create"
+          href="/ucsborganizations/create"
           style={{ float: "right" }}
         >
           Create UCSBOrganization

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
@@ -115,6 +115,6 @@ describe("UCSBOrganizationCreatePage tests", () => {
     expect(mockToast).toBeCalledWith(
       "New UCSBOrganization Created - orgCode: ZPR orgTranslationShort: ZETA PHI RHO",
     );
-    expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
+    expect(mockNavigate).toBeCalledWith({ to: "/ucsborganizations" });
   });
 });

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
@@ -172,7 +172,7 @@ describe("UCSBOrganizationEditPage tests", () => {
       expect(mockToast).toBeCalledWith(
         "UCSBOrganization Updated - orgCode: ZPR orgTranslationShort: ZETA PHI RHO UPDATED",
       );
-      expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
+      expect(mockNavigate).toBeCalledWith({ to: "/ucsborganizations" });
 
       expect(axiosMock.history.put.length).toBe(1);
       expect(axiosMock.history.put[0].params).toEqual({ orgCode: "ZPR" });

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.jsx
@@ -63,7 +63,7 @@ describe("UCSBOrganizationIndexPage tests", () => {
       expect(screen.getByText(/Create UCSBOrganization/)).toBeInTheDocument();
     });
     const button = screen.getByText(/Create UCSBOrganization/);
-    expect(button).toHaveAttribute("href", "/ucsborganization/create");
+    expect(button).toHaveAttribute("href", "/ucsborganizations/create");
     expect(button).toHaveAttribute("style", "float: right;");
   });
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** This is a REST controller for UCSBOrganization */
 @Tag(name = "UCSBOrganization")
-@RequestMapping("/api/UCSBOrganization")
+@RequestMapping("/api/ucsborganizations")
 @RestController
 @Slf4j
 public class UCSBOrganizationController extends ApiController {

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -37,19 +37,19 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
   @Test
   public void logged_out_users_cannot_get_all() throws Exception {
-    mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().is(403));
+    mockMvc.perform(get("/api/ucsborganizations/all")).andExpect(status().is(403));
   }
 
   @WithMockUser(roles = {"USER"})
   @Test
   public void logged_in_users_can_get_all() throws Exception {
-    mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().is(200));
+    mockMvc.perform(get("/api/ucsborganizations/all")).andExpect(status().is(200));
   }
 
   @Test
   public void logged_out_users_cannot_get_by_id() throws Exception {
     mockMvc
-        .perform(get("/api/UCSBOrganization").param("orgCode", "ZPR"))
+        .perform(get("/api/ucsborganizations").param("orgCode", "ZPR"))
         .andExpect(status().is(403));
   }
 
@@ -57,7 +57,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   public void logged_out_users_cannot_post() throws Exception {
     mockMvc
         .perform(
-            post("/api/UCSBOrganization/post")
+            post("/api/ucsborganizations/post")
                 .param("orgCode", "ZPR")
                 .param("orgTranslationShort", "Zeta Phi Rho")
                 .param("orgTranslation", "Zeta Phi Rho Fraternity")
@@ -71,7 +71,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   public void logged_in_regular_users_cannot_post() throws Exception {
     mockMvc
         .perform(
-            post("/api/UCSBOrganization/post")
+            post("/api/ucsborganizations/post")
                 .param("orgCode", "ZPR")
                 .param("orgTranslationShort", "Zeta Phi Rho")
                 .param("orgTranslation", "Zeta Phi Rho Fraternity")
@@ -105,7 +105,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrgs);
 
     MvcResult response =
-        mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().isOk()).andReturn();
+        mockMvc.perform(get("/api/ucsborganizations/all")).andExpect(status().isOk()).andReturn();
 
     verify(ucsbOrganizationRepository, times(1)).findAll();
     String expectedJson = mapper.writeValueAsString(expectedOrgs);
@@ -128,7 +128,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
     MvcResult response =
         mockMvc
-            .perform(get("/api/UCSBOrganization").param("orgCode", "ZPR"))
+            .perform(get("/api/ucsborganizations").param("orgCode", "ZPR"))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -145,7 +145,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
     MvcResult response =
         mockMvc
-            .perform(get("/api/UCSBOrganization").param("orgCode", "DNE"))
+            .perform(get("/api/ucsborganizations").param("orgCode", "DNE"))
             .andExpect(status().isNotFound())
             .andReturn();
 
@@ -171,7 +171,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     MvcResult response =
         mockMvc
             .perform(
-                post("/api/UCSBOrganization/post")
+                post("/api/ucsborganizations/post")
                     .param("orgCode", "ZPR")
                     .param("orgTranslationShort", "Zeta Phi Rho")
                     .param("orgTranslation", "Zeta Phi Rho Fraternity")
@@ -202,7 +202,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     MvcResult response =
         mockMvc
             .perform(
-                post("/api/UCSBOrganization/post")
+                post("/api/ucsborganizations/post")
                     .param("orgCode", "OSLI")
                     .param("orgTranslationShort", "Student Life")
                     .param("orgTranslation", "Office of Student Life")
@@ -243,7 +243,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     MvcResult response =
         mockMvc
             .perform(
-                put("/api/UCSBOrganization")
+                put("/api/ucsborganizations")
                     .param("orgCode", "ZPR")
                     .contentType(MediaType.APPLICATION_JSON)
                     .characterEncoding("utf-8")
@@ -276,7 +276,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     MvcResult response =
         mockMvc
             .perform(
-                put("/api/UCSBOrganization")
+                put("/api/ucsborganizations")
                     .param("orgCode", "DNE")
                     .contentType(MediaType.APPLICATION_JSON)
                     .characterEncoding("utf-8")
@@ -305,7 +305,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
     MvcResult response =
         mockMvc
-            .perform(delete("/api/UCSBOrganization").param("orgCode", "ZPR").with(csrf()))
+            .perform(delete("/api/ucsborganizations").param("orgCode", "ZPR").with(csrf()))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -323,7 +323,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
     MvcResult response =
         mockMvc
-            .perform(delete("/api/UCSBOrganization").param("orgCode", "DNE").with(csrf()))
+            .perform(delete("/api/ucsborganizations").param("orgCode", "DNE").with(csrf()))
             .andExpect(status().isNotFound())
             .andReturn();
 


### PR DESCRIPTION
Was running into "Error communicating with backend via GET on /api/ucsborganizations/all" when testing the navbar on dokku. Suspected due to inconsistency between url in code alternating between "ucsborganization" and "ucsborganizations", as well as "UCSBOrganization" used in Controller files.