### PR TITLE
rx - menuitemreview e2etest fix wrong column header name

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/web/MenuItemReviewWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/MenuItemReviewWebIT.java
@@ -44,7 +44,9 @@ public class MenuItemReviewWebIT extends WebTestCase {
 
     page.getByTestId("MenuItemReviewTable-cell-row-0-col-Delete-button").click();
 
-    assertThat(page.getByTestId("MenuItemReviewTable-cell-row-0-col-name")).not().isVisible();
+    assertThat(page.getByTestId("MenuItemReviewTable-cell-row-0-col-reviewerEmail"))
+        .not()
+        .isVisible();
   }
 
   @Test


### PR DESCRIPTION
Closes #111 
Fixed wrong column name used in the test for "regular user can't create".