### PR TITLE
Add HelpRequest integration and end-to-end tests

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/integration/HelpRequestIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/integration/HelpRequestIT.java
@@ -1,0 +1,116 @@
+package edu.ucsb.cs156.example.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+@Import(TestConfig.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class HelpRequestIT {
+
+  @Autowired public CurrentUserService currentUserService;
+
+  @Autowired public GrantedAuthoritiesService grantedAuthoritiesService;
+
+  @Autowired HelpRequestRepository helpRequestRepository;
+
+  @Autowired public MockMvc mockMvc;
+
+  @Autowired public ObjectMapper mapper;
+
+  @MockitoBean UserRepository userRepository;
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+    // arrange
+    LocalDateTime requestTime = LocalDateTime.parse("2024-01-01T12:00:00");
+
+    HelpRequest helpRequest =
+        HelpRequest.builder()
+            .requesterEmail("student@ucsb.edu")
+            .teamId("s26-07")
+            .tableOrBreakoutRoom("table1")
+            .requestTime(requestTime)
+            .explanation("Need help with the project")
+            .solved(false)
+            .build();
+
+    helpRequestRepository.save(helpRequest);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/helprequests?id=1")).andExpect(status().isOk()).andReturn();
+
+    // assert
+    String expectedJson = mapper.writeValueAsString(helpRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_help_request() throws Exception {
+    // arrange
+    LocalDateTime requestTime = LocalDateTime.parse("2024-01-01T12:00:00");
+
+    HelpRequest expectedHelpRequest =
+        HelpRequest.builder()
+            .id(1L)
+            .requesterEmail("student@ucsb.edu")
+            .teamId("s26-07")
+            .tableOrBreakoutRoom("table1")
+            .requestTime(requestTime)
+            .explanation("NeedHelpWithProject")
+            .solved(false)
+            .build();
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/helprequests/post"
+                        + "?requesterEmail=student@ucsb.edu"
+                        + "&teamId=s26-07"
+                        + "&tableOrBreakoutRoom=table1"
+                        + "&requestTime=2024-01-01T12:00:00"
+                        + "&explanation=NeedHelpWithProject"
+                        + "&solved=false")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    String expectedJson = mapper.writeValueAsString(expectedHelpRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/web/HelpRequestWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/HelpRequestWebIT.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class HelpRequestWebIT extends WebTestCase {
+
+  @Test
+  public void admin_user_can_create_edit_delete_help_request() throws Exception {
+    setupUser(true);
+
+    page.getByText("HelpRequest").click();
+
+    page.getByText("Create Help Request").click();
+    assertThat(page.getByText("Create New Help Request")).isVisible();
+
+    page.getByTestId("HelpRequestForm-requesterEmail").fill("student@ucsb.edu");
+    page.getByTestId("HelpRequestForm-teamId").fill("s26-07");
+    page.getByTestId("HelpRequestForm-tableOrBreakoutRoom").fill("table1");
+    page.getByTestId("HelpRequestForm-requestTime").fill("2024-01-01T12:00");
+    page.getByTestId("HelpRequestForm-explanation").fill("NeedHelpWithProject");
+    page.getByTestId("HelpRequestForm-submit").click();
+
+    assertThat(page.getByTestId("HelpRequestsTable-cell-row-0-col-requesterEmail"))
+        .hasText("student@ucsb.edu");
+
+    page.getByTestId("HelpRequestsTable-cell-row-0-col-Edit-button").click();
+    assertThat(page.getByText("Edit Help Request")).isVisible();
+    page.getByTestId("HelpRequestForm-explanation").fill("UpdatedExplanation");
+    page.getByTestId("HelpRequestForm-submit").click();
+
+    assertThat(page.getByTestId("HelpRequestsTable-cell-row-0-col-explanation"))
+        .hasText("UpdatedExplanation");
+
+    page.getByTestId("HelpRequestsTable-cell-row-0-col-Delete-button").click();
+
+    assertThat(page.getByTestId("HelpRequestsTable-cell-row-0-col-requesterEmail"))
+        .not()
+        .isVisible();
+  }
+
+  @Test
+  public void regular_user_cannot_create_help_request() throws Exception {
+    setupUser(false);
+
+    page.getByText("HelpRequest").click();
+
+    assertThat(page.getByText("Create Help Request")).not().isVisible();
+    assertThat(page.getByTestId("HelpRequestsTable-cell-row-0-col-requesterEmail"))
+        .not()
+        .isVisible();
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #126 and #127
- Adds `HelpRequestIT.java`: integration tests against a real database — GET by ID (USER) and POST new request (ADMIN)
- Adds `HelpRequestWebIT.java`: Playwright end-to-end tests — admin can create/edit/delete a help request via the UI, regular user cannot see the Create button

## Tests
- [ ] `mvn clean && INTEGRATION=true mvn test-compile`
- [ ] `INTEGRATION=true mvn failsafe:integration-test -Dit.test=HelpRequestIT` — 2 tests pass
- [ ] `INTEGRATION=true mvn failsafe:integration-test -Dit.test=HelpRequestWebIT` — 2 tests pass
