### PR TITLE
Add UCSBOrganization integration and end-to-end tests

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/integration/UCSBOrganizationIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/integration/UCSBOrganizationIT.java
@@ -1,0 +1,107 @@
+package edu.ucsb.cs156.example.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+@Import(TestConfig.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class UCSBOrganizationIT {
+
+  @Autowired public CurrentUserService currentUserService;
+
+  @Autowired public GrantedAuthoritiesService grantedAuthoritiesService;
+
+  @Autowired UCSBOrganizationRepository ucsbOrganizationRepository;
+
+  @Autowired public MockMvc mockMvc;
+
+  @Autowired public ObjectMapper mapper;
+
+  @MockitoBean UserRepository userRepository;
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+    // arrange
+    UCSBOrganization org =
+        UCSBOrganization.builder()
+            .orgCode("ZPR")
+            .orgTranslationShort("ZetaPhiRho")
+            .orgTranslation("ZetaPhiRhoFull")
+            .inactive(false)
+            .build();
+
+    ucsbOrganizationRepository.save(org);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsborganizations?orgCode=ZPR"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    String expectedJson = mapper.writeValueAsString(org);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_organization() throws Exception {
+    // arrange
+    UCSBOrganization expectedOrg =
+        UCSBOrganization.builder()
+            .orgCode("ZPR")
+            .orgTranslationShort("ZetaPhiRho")
+            .orgTranslation("ZetaPhiRhoFull")
+            .inactive(false)
+            .build();
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/ucsborganizations/post"
+                        + "?orgCode=ZPR"
+                        + "&orgTranslationShort=ZetaPhiRho"
+                        + "&orgTranslation=ZetaPhiRhoFull"
+                        + "&inactive=false")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    String expectedJson = mapper.writeValueAsString(expectedOrg);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/web/UCSBOrganizationWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/UCSBOrganizationWebIT.java
@@ -1,0 +1,58 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class UCSBOrganizationWebIT extends WebTestCase {
+
+  @Test
+  public void admin_user_can_create_edit_delete_organization() throws Exception {
+    setupUser(true);
+
+    page.getByText("UCSBOrganization").click();
+
+    page.getByText("Create UCSBOrganization").click();
+    assertThat(page.getByText("Create New UCSBOrganization")).isVisible();
+
+    page.getByTestId("UCSBOrganizationForm-orgCode").fill("ZPR");
+    page.getByTestId("UCSBOrganizationForm-orgTranslationShort").fill("ZetaPhiRho");
+    page.getByTestId("UCSBOrganizationForm-orgTranslation").fill("ZetaPhiRhoFull");
+    page.getByTestId("UCSBOrganizationForm-submit").click();
+
+    assertThat(page.getByTestId("UCSBOrganizationTable-cell-row-0-col-orgCode")).hasText("ZPR");
+
+    page.getByTestId("UCSBOrganizationTable-cell-row-0-col-Edit-button").click();
+    assertThat(page.getByText("Edit UCSBOrganization")).isVisible();
+    page.getByTestId("UCSBOrganizationForm-orgTranslation").fill("ZetaPhiRhoUpdated");
+    page.getByTestId("UCSBOrganizationForm-submit").click();
+
+    assertThat(page.getByTestId("UCSBOrganizationTable-cell-row-0-col-orgTranslation"))
+        .hasText("ZetaPhiRhoUpdated");
+
+    page.getByTestId("UCSBOrganizationTable-cell-row-0-col-Delete-button").click();
+
+    assertThat(page.getByTestId("UCSBOrganizationTable-cell-row-0-col-orgCode")).not().isVisible();
+  }
+
+  @Test
+  public void regular_user_cannot_create_organization() throws Exception {
+    setupUser(false);
+
+    page.getByText("UCSBOrganization").click();
+
+    assertThat(page.getByText("Create UCSBOrganization")).not().isVisible();
+    assertThat(page.getByTestId("UCSBOrganizationTable-cell-row-0-col-orgCode")).not().isVisible();
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #126 and #127
- Adds `UCSBOrganizationIT.java`: integration tests against a real database — GET by orgCode (USER) and POST new organization (ADMIN)
- Adds `UCSBOrganizationWebIT.java`: Playwright end-to-end tests — admin can create/edit/delete an organization via the UI, regular user cannot see the Create button